### PR TITLE
Fix local import

### DIFF
--- a/jvgrep.go
+++ b/jvgrep.go
@@ -1,10 +1,10 @@
 package main
 
 import (
-	"./mmap"
 	"bytes"
 	"code.google.com/p/mahonia"
 	"fmt"
+	"github.com/mattn/jvgrep/mmap"
 	"io/ioutil"
 	"os"
 	"path/filepath"


### PR DESCRIPTION
This fixes following error:

```
$ go get -u github.com/mattn/jvgrep
$GOPATH/src/github.com/mattn/jvgrep/jvgrep.go:4:2: local import "./mmap" in non-local package
```
