### PR TITLE
exclude vcs directory only exactly.

### DIFF
--- a/jvgrep.go
+++ b/jvgrep.go
@@ -57,7 +57,7 @@ type GrepArg struct {
 	bom     []byte
 }
 
-const excludeDefaults = `\.git$|\.svn$|\.hg$|\.o$|\.obj$|\.a$|\.exe~?$|/tags$`
+const excludeDefaults = `/\.git$|/\.svn$|/\.hg$|\.o$|\.obj$|\.a$|\.exe~?$|/tags$`
 
 var (
 	encs         string       // encodings


### PR DESCRIPTION
jvgrep doesn't work on directories which end with `.git` like `git.eclipse.org/gitroot/paho/org.eclipse.paho.mqtt.golang.git` (it is a major MQTT client library for golang)

This PR fix it.