### PR TITLE
reset bold

### DIFF
--- a/jvgrep.go
+++ b/jvgrep.go
@@ -33,7 +33,7 @@ const (
 	CYAN    = "\x1b[36;1m"
 	GREEN   = "\x1b[32;1m"
 	RED     = "\x1b[31;1m"
-	RESET   = "\x1b[39m"
+	RESET   = "\x1b[39;0m"
 )
 
 var encodings = []string{


### PR DESCRIPTION
I found a bug that jvgrep didn't reset bold sequence.

![_2016-02-01_10-55-51](https://cloud.githubusercontent.com/assets/1822861/12707185/efba12ba-c8d3-11e5-9d21-975647fa7809.png)
I fixed it.

![_2016-02-01_10-58-20](https://cloud.githubusercontent.com/assets/1822861/12707194/1e371048-c8d4-11e5-9d40-8863d878c887.png)
