### PR TITLE
fix excludeDefaults for vcs directory

### DIFF
--- a/jvgrep.go
+++ b/jvgrep.go
@@ -57,7 +57,7 @@ type GrepArg struct {
 	bom     []byte
 }
 
-const excludeDefaults = `/\.git$|/\.svn$|/\.hg$|\.o$|\.obj$|\.a$|\.exe~?$|/tags$`
+const excludeDefaults = `(^|\/)\.git$|(^|\/)\.svn$|(^|\/)\.hg$|\.o$|\.obj$|\.a$|\.exe~?$|(^|\/)tags$`
 
 var (
 	encs         string       // encodings


### PR DESCRIPTION
jvgrep walk vcs (and tags) directory at current directory because '/' is not exist at first.
This PR fix it.