### PR TITLE
Help exclude nothing

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -31,21 +31,26 @@ Usage
     -8               : show result as utf8 text
     -F               : PATTERN is a set of newline-separated fixed strings
     -G               : PATTERN is a basic regular expression (BRE)
-    -P               : PATTERN is a Perl regular expression
+    -P               : PATTERN is a Perl regular expression (ERE)
     -R               : search files recursively
     -S               : verbose messages
     -V               : print version information and exit
     --enc encodings  : encodings: comma separated
     --exclude regexp : exclude files: specify as regexp
-                       (default: \.git|\.svn|\.hg)
+                       (default: /\.git$|/\.svn$|/\.hg$|\.o$|\.obj$|\.a$|\.exe~?$|/tags$)
+    --no-color       : do not print colors
     --color [=WHEN]  : always/never/auto
+    -c               : count matches
     -r               : print relative path
     -f file          : obtain pattern file
-    -i               : ignore case(currently fixed only)
+    -i               : ignore case
     -l               : print only names of FILEs containing matches
+    -I               : ignore binary files
     -n               : print line number with output lines
     -o               : show only the part of a line matching PATTERN
     -v               : select non-matching lines
+    -z               : a data line ends in 0 byte, not newline
+    -Z               : print 0 byte after FILE name
   
     Supported Encodings:
       ascii
@@ -53,7 +58,8 @@ Usage
       utf-8
       euc-jp
       sjis
-      utf-16
+      utf-16le
+      utf-16be
 
 for example,
 

--- a/README.mkd
+++ b/README.mkd
@@ -38,6 +38,7 @@ Usage
     --enc encodings  : encodings: comma separated
     --exclude regexp : exclude files: specify as regexp
                        (default: /\.git$|/\.svn$|/\.hg$|\.o$|\.obj$|\.a$|\.exe~?$|/tags$)
+                       (specifying empty string won't exclude any files)
     --no-color       : do not print colors
     --color [=WHEN]  : always/never/auto
     -c               : count matches

--- a/jvgrep.go
+++ b/jvgrep.go
@@ -591,6 +591,7 @@ Output control:
   --enc encodings  : encodings: comma separated
   --exclude regexp : exclude files: specify as regexp
                      (default: %s)
+                     (specifying empty string won't exclude any files)
   --no-color       : do not print colors
   --color [=WHEN]  : always/never/auto
   -c               : count matches


### PR DESCRIPTION
Added description about `jvgrep --exclude ""` (exclude nothing).
This branch is based on `update-help` branch in #48.

(You can merge this branch if you would merge both changes)