### PR TITLE
Accept trailing number for the options -A and -B like -A2

### DIFF
--- a/jvgrep.go
+++ b/jvgrep.go
@@ -592,13 +592,19 @@ func main() {
 		if len(argv[n]) > 1 && argv[n][0] == '-' && argv[n][1] != '-' {
 			switch argv[n][1] {
 			case 'A':
-				if n < argc-1 {
+				if len(argv[n]) > 2 {
+					after, _ = strconv.Atoi(argv[n][2:])
+					continue
+				} else if n < argc-1 {
 					after, _ = strconv.Atoi(argv[n+1])
 					n++
 					continue
 				}
 			case 'B':
-				if n < argc-1 {
+				if len(argv[n]) > 2 {
+					before, _ = strconv.Atoi(argv[n][2:])
+					continue
+				} else if n < argc-1 {
 					before, _ = strconv.Atoi(argv[n+1])
 					n++
 					continue


### PR DESCRIPTION
jvgrep currently does not parse the trailing number after `A` or `B` options like `-A2`.
This PR fixes  it.