### PR TITLE
Fix wrong error check

### DIFF
--- a/jvgrep.go
+++ b/jvgrep.go
@@ -875,7 +875,7 @@ func doMain() int {
 				atty:    atty,
 			}
 			continue
-		} else if err != nil && fi.Mode().IsDir() && !strings.Contains(arg, "*") {
+		} else if err == nil && fi.Mode().IsDir() && !strings.Contains(arg, "*") {
 			errorLine(fmt.Sprintf("jvgrep: %s: No such file or directory", arg))
 			os.Exit(1)
 		}


### PR DESCRIPTION
fi(os.FileInfo) is nil when err is not nil. And this causes panic.

```
% jvgrep foo non-exists-file.txt
panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x30 pc=0x40818f]

goroutine 1 [running]:
panic(0x505a80, 0xc42000e0f0)
	/opt/go/src/runtime/panic.go:500 +0x1a1
main.doMain(0xc4200001a0)
	/home/syohei/go/src/github.com/mattn/jvgrep/jvgrep.go:878 +0x314f
main.main()
	/home/syohei/go/src/github.com/mattn/jvgrep/jvgrep.go:1066 +0x22
```
