### PR TITLE
Search current directory if stdin is a tty and target is not specified

### DIFF
--- a/jvgrep.go
+++ b/jvgrep.go
@@ -583,6 +583,7 @@ Regexp selection and interpretation:
   -i               : ignore case
   -z, --null-data  : a data line ends in 0 byte, not newline
   --enc=ENCODINGS  : encodings of input files: comma separated
+  --tty            : allow to search stdin even it is connected to a tty
 
 Miscellaneous:
   -S               : verbose messages
@@ -603,7 +604,6 @@ Output control:
   -l               : print only names of FILEs containing matches
   -n               : print line number with output lines
   -o               : show only the part of a line matching PATTERN
-  --tty            : allow to search stdin even it is connected to a tty
   -v               : select non-matching lines
   -Z, --null       : print 0 byte after FILE name
   --separator=CHAR : set column separator to CHAR (default: ":")

--- a/jvgrep.go
+++ b/jvgrep.go
@@ -869,14 +869,18 @@ func doMain() int {
 	}
 
 	if len(args) == 1 && argindex != 0 {
-		if Grep(&GrepArg{
-			pattern: pattern,
-			input:   os.Stdin,
-			size:    -1,
-			single:  true,
-			atty:    atty,
-		}) {
-			return 1
+		if isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd()) {
+			args = append(args, ".")
+		} else {
+			if Grep(&GrepArg{
+				pattern: pattern,
+				input:   os.Stdin,
+				size:    -1,
+				single:  true,
+				atty:    atty,
+			}) {
+				return 1
+			}
 		}
 	}
 

--- a/jvgrep.go
+++ b/jvgrep.go
@@ -81,6 +81,7 @@ var (
 	cwd, _       = os.Getwd() // current directory
 	zeroFile     bool         // write \0 after the filename
 	zeroData     bool         // write \0 after the match
+	allowTty     bool         // allow to search tty
 	countMatch   = 0          // count of matches
 	count        bool         // count of matches
 	column       bool         // show column
@@ -602,6 +603,7 @@ Output control:
   -l               : print only names of FILEs containing matches
   -n               : print line number with output lines
   -o               : show only the part of a line matching PATTERN
+  --tty            : allow to search stdin even it is connected to a tty
   -v               : select non-matching lines
   -Z, --null       : print 0 byte after FILE name
   --separator=CHAR : set column separator to CHAR (default: ":")
@@ -727,6 +729,8 @@ func parseOptions() []string {
 				zeroFile = true
 			case name == "null-data":
 				zeroData = true
+			case name == "tty":
+				allowTty = true
 			case name == "version":
 				showVersion()
 			case name == "help":
@@ -869,7 +873,7 @@ func doMain() int {
 	}
 
 	if len(args) == 1 && argindex != 0 {
-		if isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd()) {
+		if (isatty.IsTerminal(os.Stdin.Fd()) || isatty.IsCygwinTerminal(os.Stdin.Fd())) && !allowTty {
 			args = append(args, ".")
 		} else {
 			if Grep(&GrepArg{


### PR DESCRIPTION
現状、検索対象の指定がない場合、stdin が検索対象となりますが、stdin が端末の場合にカレントディレクトリを検索対象とするように変更します。
stdin がリダイレクトされている場合は、今までと同様に stdin を検索対象とします。
grepとの互換性は低くなってしまいますが、検索対象の指定がなく、かつ stdin が端末の場合に stdin を検索するという現状の動作に有用な使い道があるとは思えません。
いかがでしょうか。