### PR TITLE
Refine help

### DIFF
--- a/README.mkd
+++ b/README.mkd
@@ -1,7 +1,7 @@
 jvgrep
 ======
 
-`jvgrep` is grep for japanese vimmer. you can find text from files that writen in another japanese encodings.
+`jvgrep` is grep for Japanese vimmer. You can find text from files that written in another Japanese encodings.
 
 ![](http://go-gyazo.appspot.com/8a66f5af5f60da99.png)
 
@@ -67,7 +67,7 @@ for example,
     # jvgrep 表[現示] "**/*.txt"
 
 `pattern` should be specify with regexp. `file` can be specify wildcard.
-You can specify `pattern` with regular expression include multi-byte characters..
+You can specify `pattern` with regular expression include multi-byte characters.
 If you want to use own encodings for jvgrep, try to set environment variable $JVGREP_ENCODINGS to specify encodings separated with comma.
 If you problem about output of jvgrep (ex: output of :grep command in vim), try to set $JVGREP_OUTPUT_ENCODING to specify encoding of output.
 

--- a/jvgrep.go
+++ b/jvgrep.go
@@ -540,11 +540,14 @@ func goGrep(ch chan *GrepArg, done chan bool) {
 }
 
 func usage(simple bool) {
-	fmt.Println("Usage: jvgrep [OPTION] [PATTERN] [FILE]...")
+	fmt.Println("Usage: jvgrep [OPTION] PATTERN [FILE]...")
 	if simple {
 		fmt.Println("Try `jvgrep --help' for more information.")
 	} else {
 		fmt.Printf(`Version %s
+Grep for Japanese vimmer. You can find text from files that written in
+another Japanese encodings.
+
 Regexp selection and interpretation:
   -F               : PATTERN is a set of newline-separated fixed strings
   -G               : PATTERN is a basic regular expression (BRE)
@@ -581,8 +584,9 @@ Experimental feature:
 Context control:
   -B               : print NUM lines of leading context
   -A               : print NUM lines of trailing context
+
 `, version, excludeDefaults)
-		fmt.Println("  Supported Encodings:")
+		fmt.Println("Supported Encodings:")
 		for _, enc := range encodings {
 			if enc != "" {
 				fmt.Println("    " + enc)


### PR DESCRIPTION
typo修正と、helpの改善です。

* Japanese は固有名詞なので、語頭は大文字。
* PATTERN は省略できないので [ ] を削除。
* このプログラムが何のためのものかを help に記載。(README 冒頭からコピー。)
* "Supported Encodings" が、"Context control:" の一部であるように見えたので、前に空行を入れ、インデントを削除して、別項目であることを明確化。