### PR TITLE
Skip when input cannot be decoded

### DIFF
--- a/jvgrep.go
+++ b/jvgrep.go
@@ -90,6 +90,8 @@ var (
 	separator    = ":"        // column separator
 )
 
+var replbytes = []byte{0xef, 0xbf, 0xbd} // bytes representation of the replacement rune '\uFFFD'
+
 func printLineZero(s string) {
 	printStr(s + "\x00")
 }
@@ -286,7 +288,7 @@ func doGrep(path string, fb []byte, arg *GrepArg) bool {
 				if lf {
 					f = f[:len(f)-1]
 				}
-				if strings.Index(string(f), "\ufffd") > -1 {
+				if bytes.Index(f, replbytes) > -1 {
 					next = -1
 					continue
 				}

--- a/jvgrep.go
+++ b/jvgrep.go
@@ -286,6 +286,10 @@ func doGrep(path string, fb []byte, arg *GrepArg) bool {
 				if lf {
 					f = f[:len(f)-1]
 				}
+				if strings.Index(string(f), "\ufffd") > -1 {
+					next = -1
+					continue
+				}
 			}
 		}
 		size = len(f)


### PR DESCRIPTION
The decoder doesn't return an error when an input character cannot be
converted. It silently replace the character with '\uFFFD', the
replacement rune.
https://godoc.org/golang.org/x/text/encoding#Decoder