### PR TITLE
add mod path suffix to release as v5.x.x

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/mattn/jvgrep
+module github.com/mattn/jvgrep/v5
 
 go 1.13
 


### PR DESCRIPTION
v5.8.2 以降 module enabled で go get すると v5.8.1 が振ってくるのを直せるはずの修正です。

無理矢理 v5.8.5 (最新) を module enabled で持ってこようとすると
こんな感じで怒られます。

```console
$ GO111MODULE=on go get github.com/mattn/jvgrep@v5.8.5
go get github.com/mattn/jvgrep@v5.8.5: github.com/mattn/jvgrep@v5.8.5: invalid version: module contains a go.mod file, so major version must be compatible: should be v0 or v1, not v5
```

なんでかなって調べてみたら v2 以降をリリースする場合は
module path に `/v2` もしくは `.v2` の suffix が要るっぽいです。
ただココに置くのが正しいのかは実際にやってみないとちょっとわかりません。