### PR TITLE
fix: run `go mod tidy`

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,10 @@ require (
 	github.com/mattn/go-isatty v0.0.17
 	github.com/saracen/walker v0.1.3
 	golang.org/x/net v0.7.0
-	golang.org/x/sync v0.1.0 // indirect
 	golang.org/x/text v0.7.0
+)
+
+require (
+	golang.org/x/sync v0.1.0 // indirect
+	golang.org/x/sys v0.5.0 // indirect
 )


### PR DESCRIPTION
relates to https://github.com/Homebrew/homebrew-core/pull/124047